### PR TITLE
fix: let only a single zstd level remain for recompression

### DIFF
--- a/files/system/etc/systemd/zram-generator.conf
+++ b/files/system/etc/systemd/zram-generator.conf
@@ -1,4 +1,4 @@
 # /etc/systemd/zram-generator.conf
 [zram0]
-compression-algorithm=lz4 zstd lz4hc
+compression-algorithm=lz4 zstd
 zram-size=min(2*ram, 16384)


### PR DESCRIPTION
lz4hc really makes no sense, like at all. ;c)