### PR TITLE
Use coreos/chunkah to rechunk the image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,14 +62,13 @@ jobs:
           # it does not do with zstd:chunked, yet!
           build_opts: --compression-format zstd
 
-          # use chunkah
-          chunkah: true
+          # use coreos/chunkah
+          chunkah: "${{ env.DO_RECHUNK }}"
 
           # use rpm-ostree compose build-chunked-oci
           build_chunked_oci: false
 
           # use hhd-dev/rechunk
-          # rechunk: "${{ env.DO_RECHUNK }}"
           rechunk: false
 
           # in case of registry failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,11 @@ jobs:
           # it does not do with zstd:chunked, yet!
           build_opts: --compression-format zstd
 
+          # use chunkah
+          chunkah: true
+
           # use rpm-ostree compose build-chunked-oci
-          build_chunked_oci: true
+          build_chunked_oci: false
 
           # use hhd-dev/rechunk
           # rechunk: "${{ env.DO_RECHUNK }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: bluebuild
 on:
   schedule:
     - cron:
-        "10 06 * * *" # build at 06:10 UTC every day
-        # (30 minutes after last ublue images start building)
+        "25 05 * * *" # build daily at 05:25 UTC
+        # (Monday: 45min after trigger of ublue-os/bazzite image build)
   push:
     paths-ignore: # don't rebuild if only documentation has changed
       - "**.md"
@@ -63,7 +63,7 @@ jobs:
           build_opts: --compression-format zstd
 
           # use rpm-ostree compose build-chunked-oci
-          build_chunked_oci: false
+          build_chunked_oci: true
 
           # use hhd-dev/rechunk
           # rechunk: "${{ env.DO_RECHUNK }}"


### PR DESCRIPTION
- `rpm-ostree compose build-chunked-oci`: 45min
- `coreos/chunkah`: 15min
- raw image build: 5min
----
adding 10min may be worth it.
Adding 40min seems too much.