### PR TITLE
Modify build_chunked_oci to use DO_RECHUNK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,8 @@ jobs:
           chunkah: false
 
           # use rpm-ostree compose build-chunked-oci
-          build_chunked_oci: "${{ env.DO_RECHUNK }}"
+          build_chunked_oci: true
+          # "${{ env.DO_RECHUNK }}"
 
           # in case of registry failure
           retry_push_count: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,10 +66,7 @@ jobs:
           chunkah: false
 
           # use rpm-ostree compose build-chunked-oci
-          build_chunked_oci: false
-
-          # use hhd-dev/rechunk
-          rechunk: "${{ env.DO_RECHUNK }}"
+          build_chunked_oci: "${{ env.DO_RECHUNK }}"
 
           # in case of registry failure
           retry_push_count: 3


### PR DESCRIPTION
No more hhd-dev/rechunk because it basically produces broken images....